### PR TITLE
Support `liff.i18n.setLang` API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -298,6 +298,18 @@ function App() {
             return await liff.permanentLink.createUrlBy(url)
           }}
         />
+        <Snippet
+          apiName="liff.i18n.setLang"
+          version="2.21.0"
+          docUrl="https://developers.line.biz/ja/reference/liff/#i18n-set-lang"
+          needRequestPayload={true}
+          skipAutoRun={true}
+          hideResponse={true}
+          defaultRequestPayload={'en'}
+          runner={async (lang) => {
+            return await liff.i18n.setLang(lang)
+          }}
+        />
       </div>
     </FilterContext.Provider>
   )


### PR DESCRIPTION
This PR adds a new playground field for `liff.i18n.setLang` API, which is released in v2.21.0.

Doc: https://developers.line.biz/ja/reference/liff/#i18n-set-lang

<img width="712" alt="image" src="https://github.com/line/liff-playground/assets/22386678/e3d8a508-1144-4991-9e8e-af0a74795b55">
