### PR TITLE
Pin version of GitHub Actions using SHA

### DIFF
--- a/.github/workflows/deploy-to-netlify.yml
+++ b/.github/workflows/deploy-to-netlify.yml
@@ -9,8 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2.5.2
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2.5.2
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/upgrade-liff-sdk.yml
+++ b/.github/workflows/upgrade-liff-sdk.yml
@@ -8,8 +8,8 @@ jobs:
   update-dep:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2.5.2
         with:
           node-version-file: '.nvmrc'
 
@@ -23,7 +23,7 @@ jobs:
           yarn build
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3.14.0
         with:
           commit-message: 'chore: upgrade LIFF SDK'
           title: 'chore: upgrade LIFF SDK'


### PR DESCRIPTION
## Description
To mitigate supply chain attacks in GitHub Actions, I pinned the version of GitHub Actions using SHA.
https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/