### PR TITLE
Provide liff.getAppLanguage() instead of liff.getLanguage() since it has been deprecated API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,11 +71,11 @@ function App() {
           }}
         />
         <Snippet
-          apiName="liff.getLanguage()"
+          apiName="liff.getAppLanguage()"
           version="2.0"
-          docUrl="https://developers.line.biz/en/reference/liff/#get-language"
+          docUrl="https://developers.line.biz/en/reference/liff/#get-app-language"
           runner={async () => {
-            return liff.getLanguage()
+            return liff.getAppLanguage()
           }}
         />
         <Snippet


### PR DESCRIPTION
## Changes

Stop providing liff.getLanguage() in the playground. This API has been deprecated with the release of liff.getAppLanguage() in v2.24.0.
ref: https://developers.line.biz/en/reference/liff/#get-language